### PR TITLE
Remove Docker Login Step from Build Action

### DIFF
--- a/.github/workflows/build-config.yml
+++ b/.github/workflows/build-config.yml
@@ -40,19 +40,7 @@ jobs:
       with:
         timezoneLinux: "America/Los_Angeles"
 
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Debugging login
-      run: |
-        echo "Logging in with user: ${{ secrets.DOCKER_USERNAME }}"
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Pull SQRL demo Docker image
+    - name: Pull SQRL Docker image
       run: docker pull datasqrl/cmd:v0.5.6
 
     - name: Run Healthcare Analytics Test


### PR DESCRIPTION
Removes the Docker login step from the build action, as public Docker images are used and no authentication is required.