### PR TITLE
Add UDF examples to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,18 @@ jobs:
               compile -c aggregation-query-test-iceberg-package.json
               compile -c aggregation-query-subscription-test-package.json
 
+          - example: udf-jbang
+            path: user-defined-function/jbang
+            tag: udf-jbang
+            test_commands: |
+              compile -c udf_jbang_package.json
+
+          - example: udf-maven
+            path: user-defined-function/maven-project
+            tag: udf-maven
+            test_commands: |
+              compile -c udf_maven_package.json
+
     env:
       TZ: 'America/Los_Angeles'
       SQRL_VERSION: 'latest'

--- a/user-defined-function/jbang/udf_jbang_package.json
+++ b/user-defined-function/jbang/udf_jbang_package.json
@@ -1,0 +1,8 @@
+{
+  "version": "1",
+  "enabled-engines": ["flink", "postgres", "kafka"],
+  "script": {
+    "main": "myudf.sqrl"
+  }
+}
+

--- a/user-defined-function/maven-project/udf_maven_package.json
+++ b/user-defined-function/maven-project/udf_maven_package.json
@@ -1,0 +1,8 @@
+{
+  "version": "1",
+  "enabled-engines": ["flink", "postgres", "kafka"],
+  "script": {
+    "main": "myudf.sqrl"
+  }
+}
+


### PR DESCRIPTION
## Summary
- Added package.json configurations for both jbang and maven-project UDF examples
- Added both UDF examples to the CI workflow build matrix
- Tested both examples successfully with docker compile

## Test plan
- [x] Tested jbang UDF compilation with docker
- [x] Tested maven-project UDF compilation with docker
- [ ] CI workflow will run automatically on PR to verify integration