### PR TITLE
Update Iceberg configs to use S3 with Hadoop catalog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,13 @@ on:
     branches: [ "main" ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 30
 
     strategy:
@@ -168,6 +172,9 @@ jobs:
         for cmd in "${cmds[@]}"; do
           echo "::group::Running: $cmd"
           docker run -i -p 8888:8888 -p 8081:8081 -p 9092:9092 \
+            -e AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" \
+            -e AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+            -e AWS_REGION="${{ secrets.AWS_REGION }}" \
             --rm -v "$PWD":/build "datasqrl/cmd:${SQRL_VERSION}" $cmd
           echo "::endgroup::"
         done

--- a/healthcare-study/healthcare-study-analytics/study_analytics_package_snowflake.json
+++ b/healthcare-study/healthcare-study-analytics/study_analytics_package_snowflake.json
@@ -18,11 +18,9 @@
   },
   "connectors": {
     "iceberg": {
-      "warehouse": "s3://my-iceberg-warehouse",
-      "catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
-      "io-impl": "org.apache.iceberg.aws.s3.S3FileIO",
-      "catalog-name": "mycatalog",
-      "catalog-database": "mydatabase"
+      "warehouse": "s3a://sqrl-examples-data-bucket/datasqrl-examples/healthcare-study-analytics-iceberg",
+      "catalog-type": "hadoop",
+      "catalog-name": "mycatalog"
     }
   }
 }

--- a/test-jobs/aggregation-query-test-iceberg-package.json
+++ b/test-jobs/aggregation-query-test-iceberg-package.json
@@ -14,7 +14,7 @@
   },
   "connectors": {
     "iceberg": {
-      "warehouse": "warehouse",
+      "warehouse": "s3a://sqrl-examples-data-bucket/datasqrl-examples/iceberg-canary",
       "catalog-type": "hadoop",
       "catalog-name": "mycatalog"
     }


### PR DESCRIPTION
## Summary
- Updated healthcare-study-analytics to use Hadoop catalog instead of Glue for simpler S3 configuration
- Updated aggregation-query-test-iceberg to use S3 path (iceberg-canary) instead of local warehouse

## Context
Local warehouse paths don't work in cloud environments where job manager and task managers need shared access. Hadoop catalog with S3 provides distributed storage compatibility.

Related issue: DataSQRL/cloud-compilation#307