### PR TITLE
Make mutations point to original table name, adapting to SQRL 0.8.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  TZ: 'America/Los_Angeles'
+  SQRL_VERSION: 'latest'
+
 jobs:
   build:
     runs-on: ubuntu-latest-4-cores
@@ -131,10 +135,6 @@ jobs:
             tag: udf-maven
             test_commands: |
               compile -c udf_maven_package.json
-
-    env:
-      TZ: 'America/Los_Angeles'
-      SQRL_VERSION: 'latest'
 
     steps:
     - uses: actions/checkout@v4

--- a/iot-sensor-metrics/tests-api/addreading1-mutation.graphql
+++ b/iot-sensor-metrics/tests-api/addreading1-mutation.graphql
@@ -1,17 +1,17 @@
 mutation {
-    AddReading1: SensorReading(event: {sensorid: 1, temperature: 101.5}) {
+    AddReading1: Readings(event: {sensorid: 1, temperature: 101.5}) {
         sensorid
     }
-    AddReading2: SensorReading(event: {sensorid: 2, temperature: 80.5}) {
+    AddReading2: Readings(event: {sensorid: 2, temperature: 80.5}) {
         sensorid
     }
-    AddReading3: SensorReading(event: {sensorid: 3, temperature: 60.2}) {
+    AddReading3: Readings(event: {sensorid: 3, temperature: 60.2}) {
         sensorid
     }
-    AddReading4: SensorReading(event: {sensorid: 2, temperature: 105.7}) {
+    AddReading4: Readings(event: {sensorid: 2, temperature: 105.7}) {
         sensorid
     }
-    AddReading5: SensorReading(event: {sensorid: 1, temperature: 73.4}) {
+    AddReading5: Readings(event: {sensorid: 1, temperature: 73.4}) {
         sensorid
     }
 }

--- a/iot-sensor-metrics/tests-api/addreading2-mutation.graphql
+++ b/iot-sensor-metrics/tests-api/addreading2-mutation.graphql
@@ -1,26 +1,26 @@
 mutation {
-    AddReading1: SensorReading(event: {sensorid: 1, temperature: 13.5}) {
+    AddReading1: Readings(event: {sensorid: 1, temperature: 13.5}) {
         temperature
     }
-    AddReading2: SensorReading(event: {sensorid: 2, temperature: 110.1}) {
+    AddReading2: Readings(event: {sensorid: 2, temperature: 110.1}) {
         temperature
     }
-    AddReading3: SensorReading(event: {sensorid: 3, temperature: 88.5}) {
+    AddReading3: Readings(event: {sensorid: 3, temperature: 88.5}) {
         temperature
     }
-    AddReading4: SensorReading(event: {sensorid: 2, temperature: 14.7}) {
+    AddReading4: Readings(event: {sensorid: 2, temperature: 14.7}) {
         temperature
     }
-    AddReading5: SensorReading(event: {sensorid: 1, temperature: 100.4}) {
+    AddReading5: Readings(event: {sensorid: 1, temperature: 100.4}) {
         temperature
     }
-    AddReading6: SensorReading(event: {sensorid: 3, temperature: 112.3}) {
+    AddReading6: Readings(event: {sensorid: 3, temperature: 112.3}) {
         temperature
     }
-    AddReading7: SensorReading(event: {sensorid: 2, temperature: 12.7}) {
+    AddReading7: Readings(event: {sensorid: 2, temperature: 12.7}) {
         temperature
     }
-    AddReading8: SensorReading(event: {sensorid: 1, temperature: 43.2}) {
+    AddReading8: Readings(event: {sensorid: 1, temperature: 43.2}) {
         temperature
     }
 }


### PR DESCRIPTION
Starting with SQRL 0.8.6, in case of a Kafka table shorthand is used, we now use the original table name for the topic, instead of the alias its imported as into the `.sqrl` script.