### PR TITLE
Use Glue catalog Iceberg canary test job

### DIFF
--- a/test-jobs/aggregation-query-test-iceberg-glue-package.json
+++ b/test-jobs/aggregation-query-test-iceberg-glue-package.json
@@ -1,0 +1,25 @@
+{
+  "version": "1",
+  "enabled-engines": ["vertx", "iceberg", "duckdb", "flink"],
+  "script": {
+    "main": "aggregation-query-test.sqrl"
+  },
+  "engines": {
+    "flink" : {
+      "config" : {
+        "table.exec.source.idle-timeout": "1 s",
+        "execution.checkpointing.interval": "1 min"
+      }
+    }
+  },
+  "connectors": {
+    "iceberg": {
+      "connector": "iceberg",
+      "warehouse": "s3://sqrl-examples-data-bucket/datasqrl-examples/iceberg-canary",
+      "catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+      "io-impl": "org.apache.iceberg.aws.s3.S3FileIO",
+      "catalog-name": "canary",
+      "catalog-database": "canary"
+    }
+  }
+}


### PR DESCRIPTION
@velo this will require a `canary` named AWS Glue database on the AWS account that is connected to the test.

Also, we cannot compile the Glue catalog package with the CI (as it is now), cause compile already requires AWS creds.