### PR TITLE
Bump SQRL version to 0.10.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   TZ: 'America/Los_Angeles'
-  SQRL_VERSION: '0.10.6'
+  SQRL_VERSION: '0.10.7'
 
 jobs:
   build-and-push:
@@ -173,7 +173,7 @@ jobs:
           IMAGE="${{ inputs.sqrl_image }}"
           IS_SNAPSHOT=true
         else
-          IMAGE="ghcr.io/datasqrl/cmd:${SQRL_VERSION}"
+          IMAGE="datasqrl/cmd:${SQRL_VERSION}"
           IS_SNAPSHOT=false
         fi
         echo "image=$IMAGE" >> "$GITHUB_OUTPUT"

--- a/finance-credit-card-chatbot/credit-card-analytics/creditcard-testdata/transaction.table.sql
+++ b/finance-credit-card-chatbot/credit-card-analytics/creditcard-testdata/transaction.table.sql
@@ -5,7 +5,7 @@ CREATE TABLE Transaction (
     amount DOUBLE NOT NULL,
     merchantId BIGINT NOT NULL,
     PRIMARY KEY (`transactionId`, `time`) NOT ENFORCED,
-    WATERMARK FOR `time` AS `time` - INTERVAL '1' SECOND
+    WATERMARK FOR `time` AS `time`
 ) WITH (
       'format' = 'flexible-json',
       'path' = '${DATA_PATH}/transaction.jsonl',


### PR DESCRIPTION
## Summary
- Bump `SQRL_VERSION` in CI workflow from previous value to `0.10.7`

Triggered automatically by the release of [`0.10.7`](https://github.com/DataSQRL/sqrl/releases/tag/0.10.7) in DataSQRL/sqrl.

## Test plan
- [ ] CI build matrix passes against `datasqrl/cmd:0.10.7`