### PR TITLE
Add a mutation-driven iceberg test job that reads back through duckdb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,7 @@ jobs:
               compile aggregation-query-test-package.json
               compile aggregation-query-test-iceberg-package.json
               compile aggregation-query-subscription-test-package.json
+              compile mutation-iceberg-test-package.json
 
           - example: canary-mutation
             path: test-jobs/mutation-tests
@@ -302,7 +303,7 @@ jobs:
           fi
 
           LINT_OPTS="--rules fields-are-camel-cased,types-are-capitalized,enum-values-all-caps,input-object-values-are-camel-cased"
-          IGNORE='{"fields-are-camel-cased":["Query.Shipment","Query.Vehicle","Query.Customer"]}'
+          IGNORE='{"fields-are-camel-cased":["Query.Shipment","Query.Vehicle","Query.Customer","Query.Aggregation","Query.Measurement","Query.Activity","Mutation.InputData"]}'
           FAILED=0
 
           for schema in $SCHEMAS; do

--- a/test-jobs/aggregation-tests/README.md
+++ b/test-jobs/aggregation-tests/README.md
@@ -47,6 +47,12 @@ curl -s http://localhost:8888/v1/graphql -H 'Content-Type: application/json' \
   -d '{"query":"{ Aggregation(limit:5){ partitionId window_start window_end total_measure record_count } }"}'
 ```
 
+> [!IMPORTANT]
+> The warehouse path is fixed, so the Iceberg tables persist between runs. If you change a column
+> in the SQRL script, compilation fails with `Field <name> not found in source schema` — Iceberg is
+> reconciling against the table already at that path. Clear it first:
+> `aws s3 rm s3://sqrl-examples-data-bucket/datasqrl-examples/iceberg-mutation-test/ --recursive`
+
 > [!NOTE]
 > Running locally, DuckDB reads S3 with the `AWS_*` environment variables above. Deployed to a
 > cluster where the pod authenticates through IRSA, the **write** side works but DuckDB queries

--- a/test-jobs/aggregation-tests/README.md
+++ b/test-jobs/aggregation-tests/README.md
@@ -8,3 +8,47 @@ testing.
 * [Aggregation](aggregation-test.sqrl): Tests Flink with logging using generated data
 * [Aggregation Query](aggregation-query-test.sqrl): Tests Flink -> Postgres or Iceberg -> Vertx using generated data
 * [Aggregation Query Subscription](aggregation-query-subscription-test.sqrl): Tests Flink -> Postgres + Kafka -> Vertx using generated data
+* [Mutation Iceberg](mutation-iceberg-test.sqrl): Tests GraphQL mutation -> Kafka -> Flink -> Iceberg on S3 -> DuckDB -> Vertx. Unlike the jobs above it has no `datagen` source, so **nothing happens until you post data**, and it computes three tables in the iceberg engine rather than one
+
+## Mutation Iceberg job
+
+`mutation-iceberg-test-package.json` writes Iceberg to `s3a://sqrl-examples-data-bucket/datasqrl-examples/iceberg-mutation-test`
+using the **hadoop** catalog. No AWS Glue is involved, so the job needs nothing beyond S3 access to
+that bucket and runs unchanged from any data group.
+
+Run it with credentials that can reach the bucket:
+
+```bash
+docker run -it --rm -p 8888:8888 -p 8081:8081 \
+  -e AWS_ACCESS_KEY_ID="<key>" \
+  -e AWS_SECRET_ACCESS_KEY="<secret>" \
+  -e AWS_REGION="us-east-1" \
+  -v $PWD:/build \
+  datasqrl/cmd:latest run mutation-iceberg-test-package.json
+```
+
+Post data — the watermark comes from the Kafka record timestamp, so windows only close while rows
+keep arriving. A single mutation will land in `Measurement` but never closes a window:
+
+```bash
+curl -s http://localhost:8888/v1/graphql -H 'Content-Type: application/json' -d '{
+  "query": "mutation($e:[InputDataInput!]!){ InputData(event:$e){ uniqueId event_time } }",
+  "variables": {"e": [{"uniqueId":"a1","measure":600.0,"partitionId":"a"}]}
+}'
+```
+
+Then read it back through DuckDB. Allow ~20-40s: a row is only queryable once Flink checkpoints and
+commits to Iceberg.
+
+```bash
+curl -s http://localhost:8888/v1/graphql -H 'Content-Type: application/json' \
+  -d '{"query":"{ Measurement(limit:5){ uniqueId partitionId measure event_time } }"}'
+curl -s http://localhost:8888/v1/graphql -H 'Content-Type: application/json' \
+  -d '{"query":"{ Aggregation(limit:5){ partitionId window_start window_end total_measure record_count } }"}'
+```
+
+> [!NOTE]
+> Running locally, DuckDB reads S3 with the `AWS_*` environment variables above. Deployed to a
+> cluster where the pod authenticates through IRSA, the **write** side works but DuckDB queries
+> return `HTTP 403`: its `httpfs` extension never exchanges the projected web-identity token. That
+> needs the credential-chain support in DataSQRL/sqrl#2098.

--- a/test-jobs/aggregation-tests/mutation-iceberg-test-package.json
+++ b/test-jobs/aggregation-tests/mutation-iceberg-test-package.json
@@ -1,0 +1,23 @@
+{
+  "version": "1",
+  "enabled-engines": ["vertx", "iceberg", "duckdb", "kafka", "flink"],
+  "script": {
+    "main": "mutation-iceberg-test.sqrl",
+    "graphql": "mutation-iceberg-test.graphqls"
+  },
+  "engines": {
+    "flink" : {
+      "config" : {
+        "table.exec.source.idle-timeout": "1 s",
+        "execution.checkpointing.interval": "20 s"
+      }
+    }
+  },
+  "connectors": {
+    "iceberg": {
+      "warehouse": "s3a://sqrl-examples-data-bucket/datasqrl-examples/iceberg-mutation-test",
+      "catalog-type": "hadoop",
+      "catalog-name": "mycatalog"
+    }
+  }
+}

--- a/test-jobs/aggregation-tests/mutation-iceberg-test.graphqls
+++ b/test-jobs/aggregation-tests/mutation-iceberg-test.graphqls
@@ -1,0 +1,52 @@
+"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats"
+scalar DateTime
+
+"A 64-bit signed integer"
+scalar Long
+
+input InputDataInput {
+  uniqueId: String!
+  measure: Float!
+  partitionId: String!
+}
+
+type InputDataResultOutput {
+  uniqueId: String!
+  measure: Float!
+  partitionId: String!
+  event_time: DateTime
+}
+
+type Aggregation {
+  partitionId: String!
+  window_start: DateTime!
+  window_end: DateTime!
+  window_time: DateTime!
+  total_measure: Float!
+  record_count: Long!
+}
+
+type Measurement {
+  uniqueId: String!
+  partitionId: String!
+  measure: Float!
+  event_time: DateTime
+}
+
+type Activity {
+  partitionId: String!
+  window_start: DateTime!
+  window_end: DateTime!
+  window_time: DateTime!
+  record_count: Long!
+}
+
+type Mutation {
+  InputData(event: [InputDataInput!]!): [InputDataResultOutput!]!
+}
+
+type Query {
+  Aggregation(limit: Int = 10, offset: Int = 0): [Aggregation!]
+  Measurement(limit: Int = 10, offset: Int = 0): [Measurement!]
+  Activity(limit: Int = 10, offset: Int = 0): [Activity!]
+}

--- a/test-jobs/aggregation-tests/mutation-iceberg-test.graphqls
+++ b/test-jobs/aggregation-tests/mutation-iceberg-test.graphqls
@@ -14,31 +14,31 @@ type InputDataResultOutput {
   uniqueId: String!
   measure: Float!
   partitionId: String!
-  event_time: DateTime
+  eventTime: DateTime
 }
 
 type Aggregation {
   partitionId: String!
-  window_start: DateTime!
-  window_end: DateTime!
-  window_time: DateTime!
-  total_measure: Float!
-  record_count: Long!
+  windowStart: DateTime!
+  windowEnd: DateTime!
+  windowTime: DateTime!
+  totalMeasure: Float!
+  recordCount: Long!
 }
 
 type Measurement {
   uniqueId: String!
   partitionId: String!
   measure: Float!
-  event_time: DateTime
+  eventTime: DateTime
 }
 
 type Activity {
   partitionId: String!
-  window_start: DateTime!
-  window_end: DateTime!
-  window_time: DateTime!
-  record_count: Long!
+  windowStart: DateTime!
+  windowEnd: DateTime!
+  windowTime: DateTime!
+  recordCount: Long!
 }
 
 type Mutation {

--- a/test-jobs/aggregation-tests/mutation-iceberg-test.sqrl
+++ b/test-jobs/aggregation-tests/mutation-iceberg-test.sqrl
@@ -1,40 +1,42 @@
 -- Unlike aggregation-test.sqrl, data does not come from datagen: it arrives through the GraphQL API
--- into a kafka-engine mutation table. event_time is the kafka record timestamp, so the watermark
+-- into a kafka-engine mutation table. eventTime is the kafka record timestamp, so the watermark
 -- only advances while rows keep being posted -- an idle API means windows never close.
 /*+engine(kafka), insert(batch) */
 CREATE TABLE InputData (
   uniqueId STRING NOT NULL,
   measure DOUBLE NOT NULL,
   partitionId STRING NOT NULL,
-  event_time TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
-  WATERMARK FOR event_time AS event_time - INTERVAL '5' SECOND
+  eventTime TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
+  WATERMARK FOR eventTime AS eventTime - INTERVAL '5' SECOND
 );
 
 -- Three tables computed in the iceberg engine, so the job covers more than a single sink.
-/*+primary_key(partitionId, window_end) */
+-- The TUMBLE columns are aliased to camelCase because the repo lints schemas with
+-- graphql-schema-linter's fields-are-camel-cased rule.
+/*+primary_key(partitionId, windowEnd) */
 Aggregation := SELECT
   partitionId,
-  window_start,
-  window_end,
-  window_time,
-  SUM(measure) AS total_measure,
-  COUNT(*) AS record_count
+  window_start AS windowStart,
+  window_end AS windowEnd,
+  window_time AS windowTime,
+  SUM(measure) AS totalMeasure,
+  COUNT(*) AS recordCount
 FROM TABLE(
-  TUMBLE(TABLE InputData, DESCRIPTOR(event_time), INTERVAL '10' SECOND)
+  TUMBLE(TABLE InputData, DESCRIPTOR(eventTime), INTERVAL '10' SECOND)
 )
 GROUP BY partitionId, window_start, window_end, window_time;
 
-Measurement := SELECT uniqueId, partitionId, measure, event_time
+Measurement := SELECT uniqueId, partitionId, measure, eventTime
 FROM InputData WHERE measure > 500.0;
 
-/*+primary_key(partitionId, window_end) */
+/*+primary_key(partitionId, windowEnd) */
 Activity := SELECT
   partitionId,
-  window_start,
-  window_end,
-  window_time,
-  COUNT(*) AS record_count
+  window_start AS windowStart,
+  window_end AS windowEnd,
+  window_time AS windowTime,
+  COUNT(*) AS recordCount
 FROM TABLE(
-  TUMBLE(TABLE InputData, DESCRIPTOR(event_time), INTERVAL '30' SECOND)
+  TUMBLE(TABLE InputData, DESCRIPTOR(eventTime), INTERVAL '30' SECOND)
 )
 GROUP BY partitionId, window_start, window_end, window_time;

--- a/test-jobs/aggregation-tests/mutation-iceberg-test.sqrl
+++ b/test-jobs/aggregation-tests/mutation-iceberg-test.sqrl
@@ -1,0 +1,40 @@
+-- Unlike aggregation-test.sqrl, data does not come from datagen: it arrives through the GraphQL API
+-- into a kafka-engine mutation table. event_time is the kafka record timestamp, so the watermark
+-- only advances while rows keep being posted -- an idle API means windows never close.
+/*+engine(kafka), insert(batch) */
+CREATE TABLE InputData (
+  uniqueId STRING NOT NULL,
+  measure DOUBLE NOT NULL,
+  partitionId STRING NOT NULL,
+  event_time TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
+  WATERMARK FOR event_time AS event_time - INTERVAL '5' SECOND
+);
+
+-- Three tables computed in the iceberg engine, so the job covers more than a single sink.
+/*+primary_key(partitionId, window_end) */
+Aggregation := SELECT
+  partitionId,
+  window_start,
+  window_end,
+  window_time,
+  SUM(measure) AS total_measure,
+  COUNT(*) AS record_count
+FROM TABLE(
+  TUMBLE(TABLE InputData, DESCRIPTOR(event_time), INTERVAL '10' SECOND)
+)
+GROUP BY partitionId, window_start, window_end, window_time;
+
+Measurement := SELECT uniqueId, partitionId, measure, event_time
+FROM InputData WHERE measure > 500.0;
+
+/*+primary_key(partitionId, window_end) */
+Activity := SELECT
+  partitionId,
+  window_start,
+  window_end,
+  window_time,
+  COUNT(*) AS record_count
+FROM TABLE(
+  TUMBLE(TABLE InputData, DESCRIPTOR(event_time), INTERVAL '30' SECOND)
+)
+GROUP BY partitionId, window_start, window_end, window_time;


### PR DESCRIPTION
Adds `mutation-iceberg-test` to `test-jobs/aggregation-tests` — a job where data arrives through the **GraphQL API** rather than `datagen`, and several tables are computed in the **iceberg** engine and read back through **DuckDB**.

Nothing in the repo covered this combination. The two existing iceberg variants of `aggregation-query-test` are `datagen`-fed and compute a single table, and **no** example enables `vertx` alongside `iceberg` — so none of them serves an API over Iceberg, which is the leg that matters most and the one most likely to break.

## What it does

```
GraphQL mutation -> Kafka -> Flink -> Iceberg (S3) -> DuckDB -> Vert.x
```

- `InputData` is a kafka-engine mutation table (`/*+engine(kafka), insert(batch) */`), so there is no topic to prime and no file to stage.
- Three tables land in the iceberg engine: `Aggregation` (10s tumble), `Measurement` (filter), `Activity` (30s tumble). A fourth appears in S3 — SQRL materializes `InputData` itself.
- Checkpointing is 20s so rows become queryable in seconds rather than the 1min the sibling variants use.

## Two deliberate choices

**S3, not a local warehouse.** `s3a://sqrl-examples-data-bucket/datasqrl-examples/iceberg-mutation-test`. A local `warehouse` dir would be simpler but the job could not then be deployed through cloud-compilation.

**Hadoop catalog, not Glue.** The existing `aggregation-query-test-iceberg-glue-package.json` pins `catalog-database: canary`, but a data group's IAM role only grants `glue:…database/sqrl<dataGroupKey>` — so the Glue variant cannot run as a real data group. The hadoop catalog skips Glue entirely, and `sqrl-examples-data-bucket` is already granted to every data group, so this job runs unchanged from any of them with **no IAM change**. Trade-off: no Glue registration, so no Athena leg.

## Verified end to end

`datasqrl/cmd:0.10.6`, run locally against real S3 with `AWS_*` env vars. Posted one probe row, then 100 rows/s for 150s:

```json
{"Aggregation":[{"partitionId":"a","total_measure":600,"record_count":1},
                {"partitionId":"d","total_measure":97905.11,"record_count":194}],
 "Measurement":[{"uniqueId":"probe-1","measure":600},{"uniqueId":"r1","measure":881.39}]}
```

The first `Aggregation` row is the single `probe-1` mutation alone in its own 10s window — end-to-end proof the path carries individual records faithfully. 45 objects written under the S3 prefix, `data/` + `metadata/` for all four tables.

## Known limitation, documented in the README

Deployed to a cluster where the pod authenticates via **IRSA**, the write side works but DuckDB queries return `HTTP 403`: its `httpfs` extension never exchanges the projected web-identity token, so it goes out anonymous. Locally it works because `httpfs` does pick up `AWS_*` environment variables. The fix is the credential-chain support in DataSQRL/sqrl#2098.
