### PR TITLE
Bump SQRL version to 0.11.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   TZ: 'America/Los_Angeles'
-  SQRL_VERSION: '0.10.8'
+  SQRL_VERSION: '0.11.1'
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Summary
- Bump `SQRL_VERSION` in CI workflow from previous value to `0.11.1`

Triggered automatically by the release of [`0.11.1`](https://github.com/DataSQRL/sqrl/releases/tag/0.11.1) in DataSQRL/sqrl.

## Test plan
- [ ] CI build matrix passes against `datasqrl/cmd:0.11.1`