### PR TITLE
[chore] Pin analytics test deploy Flink TaskManager to NVMe nodes

### DIFF
--- a/finance-credit-card-chatbot/credit-card-analytics/creditcard_analytics-test-package.json
+++ b/finance-credit-card-chatbot/credit-card-analytics/creditcard_analytics-test-package.json
@@ -5,6 +5,11 @@
     }
   },
   "engines": {
+    "flink": {
+      "deployment": {
+        "taskmanager-dedicated-nodes": ["nvme"]
+      }
+    },
     "vertx": {
       "authKind": ["JWT"],
       "config": {

--- a/finance-credit-card-chatbot/credit-card-analytics/creditcard_analytics-test-package.json
+++ b/finance-credit-card-chatbot/credit-card-analytics/creditcard_analytics-test-package.json
@@ -1,11 +1,22 @@
 {
+  "version": "1",
+  "enabled-engines": ["vertx", "postgres", "kafka", "flink"],
   "script": {
+    "main": "creditcard_analytics.sqrl",
+    "include": {
+      "data-catalog": {
+        "package": "../data-catalog/package.json"
+      }
+    },
     "config": {
       "environment": "test"
     }
   },
   "engines": {
     "flink": {
+      "config": {
+        "table.exec.source.idle-timeout": "10 s"
+      },
       "deployment": {
         "taskmanager-dedicated-nodes": ["nvme"]
       }

--- a/test-jobs/scheduled-batch-test/simple-scheduled-batch-package.json
+++ b/test-jobs/scheduled-batch-test/simple-scheduled-batch-package.json
@@ -14,6 +14,7 @@
         "jobmanager-size": "small",
         "taskmanager-size": "small",
         "taskmanager-count": 1,
+        "taskmanager-dedicated-nodes": ["nvme"],
         "schedule": {
           "cron": "*/15 * * * *",
           "timezone": "UTC"


### PR DESCRIPTION
## What was done
- Added `taskmanager-dedicated-nodes: ["nvme"]` to the Flink engine deployment config in `creditcard_analytics-test-package.json`

## Why it was done
- Pins the Flink TaskManager pods onto the `sqrlpipeline-nvme` Karpenter NodePool (label `nvme=true` + toleration for the `nvme` taint), so RocksDB state runs on local NVMe-backed disk
- JobManager is left unpinned per the cloud-docs recommendation to keep costs down